### PR TITLE
Automated cherry pick of #11: feat: keep cloudresource when resource in k8s is invalid

### DIFF
--- a/api/v1/common.go
+++ b/api/v1/common.go
@@ -138,7 +138,9 @@ func (rb *ResourceStatusBase) GetPhase() ResourcePhase {
 
 func (rb *ResourceStatusBase) SetPhase(phase ResourcePhase, reason string) {
 	rb.Phase = phase
-	rb.Reason = reason
+	if len(reason) > 0 {
+		rb.Reason = reason
+	}
 }
 
 func (rb *ResourceStatusBase) GetTryTimes() int32 {


### PR DESCRIPTION
Cherry pick of #11 on release/3.4.

#11: feat: keep cloudresource when resource in k8s is invalid